### PR TITLE
fix svg height scaling in grid

### DIFF
--- a/src/components/t3.astro
+++ b/src/components/t3.astro
@@ -1,7 +1,9 @@
 <svg
   viewBox="0 0 258 198"
   xmlns="http://www.w3.org/2000/svg"
-  class="h-48 md:h-[12.4rem] fill-slate-200"
+  class="h-auto w-full fill-slate-200 md:h-full md:w-auto"
+  width="258"
+  height="198"
 >
   <g transform="matrix(1,0,0,1,-0.465994,-0.972412)">
     <path

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,9 +34,7 @@ import Discordsvg from "../assets/platforms/discord.svg.astro";
       <div
         class="flex h-screen w-full items-center justify-center p-4 align-middle text-slate-200"
       >
-        <div
-          class="grid grid-cols-1 md:grid-cols-[1fr_auto] grid-rows-2 md:grid-rows-[1fr]"
-        >
+        <div class="grid md:grid-flow-col">
           <T3SVG />
           <div class="px-4 py-4 text-center md:py-0 md:text-left">
             <h1 class="text-2xl font-bold leading-none">T3 Stuff</h1>


### PR DESCRIPTION
Fix cross browser SVG scaling issue. Setting the width and height attributes in the SVG fixes the cross browser sizing problem inside the grid. The additional classes for with and height allow resizing again (this also fixes the logo for even smaller sizes). 
