### PR TITLE
Simple SVG fix

### DIFF
--- a/src/components/t3.astro
+++ b/src/components/t3.astro
@@ -1,7 +1,7 @@
 <svg
   viewBox="0 0 258 198"
   xmlns="http://www.w3.org/2000/svg"
-  class="h-full max-h-48 mx-auto aspect-[13/10] fill-slate-200"
+  class="h-full max-h-48 mx-auto fill-slate-200"
 >
   <g transform="matrix(1,0,0,1,-0.465994,-0.972412)">
     <path

--- a/src/components/t3.astro
+++ b/src/components/t3.astro
@@ -1,7 +1,7 @@
 <svg
   viewBox="0 0 258 198"
   xmlns="http://www.w3.org/2000/svg"
-  class="h-48 md:h-[12.4rem] fill-slate-200"
+  class="h-full max-h-48 mx-auto aspect-[13/10] fill-slate-200"
 >
   <g transform="matrix(1,0,0,1,-0.465994,-0.972412)">
     <path

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ import Discordsvg from "../assets/platforms/discord.svg.astro";
         class="flex h-screen w-full items-center justify-center p-4 align-middle text-slate-200"
       >
         <div
-          class="grid grid-cols-1 md:grid-cols-[1fr_auto] grid-rows-2 md:grid-rows-[1fr]"
+          class="grid grid-cols-1 md:grid-cols-2 md:min-w-[32rem]"
         >
           <T3SVG />
           <div class="px-4 py-4 text-center md:py-0 md:text-left">


### PR DESCRIPTION
I tried to check the diffs in FF and chrome on base case of grid implementation sizes and in chrome its 520/200 while FF showed it only 320/200 or something close to those numbers, without the min width of the grid and the max height in the SVG it's for less than md screen sizes.

not sure about safari though because I do not own apple devices to check it.

hope it's giving a better and more responsive design even if it's not really far from what you already hacked around with custom tailwind classes.

I started to learn how to use tailwind and thought it's nice challenge to take for improving glad to take feedback about my approach thanks